### PR TITLE
feat: support upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # openGemini-UP
-Cluster deployment and upgrade tool
+
+Cluster deployment and upgrade tool.
+
+## Build
+
+```bash
+git clone git@github.com:openGemini/openGemini-UP.git
+
+cd openGemini-UP
+
+go mod tidy
+
+go build
+```
+
+## Commands
+
+The following table describes some commonly used basic commands.
+
+| command | description | parameter | example |
+| --- | --- | --- | --- |
+| `version` | display version number of openGemini-UP | no para | `./openGemini-UP version` |
+| `list` | display the version information of all components currently downloaded | no para | `./openGemini-UP list` |
+| `install` | install database components | --version | `./openGemini-UP install --version v1.0.0` |
+| `cluster` | deploying and managing openGemini clusters | have subcommand | |
+
+The following table describes the subcommands of the `cluster` command.
+
+| command | description | parameter | example |
+| --- | --- | --- | --- |
+| `deploy` | deploy an openGemini cluster| --version | `./openGemini-UP cluster deploy --version v1.0.0` |
+| `stop` | stop an openGemini cluster | no para | `./openGemini-UP cluster stop` |
+| `start` | start an openGemini cluster which is stopped | no para | `./openGemini-UP cluster start` |
+| `destroy` | destroy an openGemini cluster which means stopping services and clearing data| no para | `./openGemini-UP cluster destroy`  |
+| `upgrade` | upgrade an openGemini cluster to the specified version | --version | `./openGemini-UP cluster upgrade --version v1.0.0`  |
+
+## up.conf
+
+The `up.conf` is written by the user and contains the necessary information for deploying the openGemini cluster. You can modify the content of the file according to the template, but please do not change the location of the file.
+
+The meaning of each part is as follows:
+
+* `common`: Describe the deployment distribution of the cluster on each machine.
+* `host`: Describe the IP address of each machine.
+* `ssh`: Describe the SSH configuration for each machin. The login methods for different machines should be the same.
+
+```toml
+[common]
+  meta = ["host1","host2","host3"]
+  store = ["host1","host2","host3"]
+  sql = ["host1"]
+
+[host]
+  name = ["host1","host2","host3"]
+  ip = ["xxx.xxx.xxx.xx1","xxx.xxx.xxx.xx2","xxx.xxx.xxx.xx3"]
+
+[ssh]
+  port = 22
+  user = "username"
+  type = "SSH_KEY"  # "SSH_PW"
+  password = "xxxxx"
+  key-path = "~/.ssh/id_rsa"
+  up-data-path = "~/openGemini-UP/"
+```

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -34,5 +34,4 @@ var startCmd = &cobra.Command{
 
 func init() {
 	clusterCmd.AddCommand(startCmd)
-	startCmd.Flags().StringP("version", "v", "", "component name")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"openGemini-UP/pkg/deploy"
+	"openGemini-UP/pkg/stop"
+	"openGemini-UP/util"
+
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "upgrade cluster",
+	Long:  `upgrade an openGemini cluster to the specified version`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("--------------- Cluster upgrading! ---------------")
+		version, _ := cmd.Flags().GetString("version")
+		if version == "" {
+			version = util.Download_version
+		}
+		fmt.Println("upgrade to cluster version: ", version)
+
+		// stop all services
+		stop := stop.NewGeminiStop(false)
+		defer stop.Close()
+		if err := stop.Prepare(); err != nil {
+			fmt.Println(err)
+			return
+		}
+		if err := stop.Run(); err != nil {
+			fmt.Println(err)
+		}
+
+		// upload new bin files and start new services
+		deployer := deploy.NewGeminiDeployer(version)
+		defer deployer.Close()
+
+		if err := deployer.PrepareForDeploy(); err != nil {
+			fmt.Println(err)
+			return
+		}
+		if err := deployer.Deploy(); err != nil {
+			fmt.Println(err)
+		}
+
+		fmt.Println("--------------- Successfully completed cluster upgrade! ---------------")
+	},
+}
+
+func init() {
+	clusterCmd.AddCommand(upgradeCmd)
+	upgradeCmd.Flags().StringP("version", "v", "", "component name")
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"golang.org/x/text/encoding/unicode"
@@ -82,8 +83,9 @@ func (c *GeminiConfigurator) RunWithoutGen() error {
 }
 
 func (c *GeminiConfigurator) generateConf() error {
-	if _, err := os.Stat(util.Download_dst + util.Local_etc_rel_path); os.IsNotExist(err) {
-		errDir := os.MkdirAll(util.Download_dst+util.Local_etc_rel_path, 0755)
+	confPah := filepath.Join(util.Download_dst, util.Local_etc_rel_path)
+	if _, err := os.Stat(confPah); os.IsNotExist(err) {
+		errDir := os.MkdirAll(confPah, 0755)
 		if errDir != nil {
 			return errDir
 		}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -185,8 +185,8 @@ func (d *GeminiDeployer) prepareForUpload() error {
 		return util.UnexpectedNil
 	}
 	for ip, r := range d.remotes {
-		binPath := r.UpDataPath + util.Remote_bin_rel_path
-		etcPath := r.UpDataPath + util.Remote_etc_rel_path
+		binPath := r.UpDataPath + d.version + util.Remote_bin_rel_path
+		etcPath := r.UpDataPath + d.version + util.Remote_etc_rel_path
 		command := fmt.Sprintf("mkdir -p %s; mkdir -p %s;", binPath, etcPath)
 		if _, err := d.executor.ExecCommand(ip, command); err != nil {
 			return err
@@ -211,7 +211,7 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_META,
-			RemotePath: d.remotes[host].UpDataPath + util.Remote_bin_rel_path,
+			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
 			FileName:   util.TS_META,
 		})
 	}
@@ -226,7 +226,7 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_SQL,
-			RemotePath: d.remotes[host].UpDataPath + util.Remote_bin_rel_path,
+			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
 			FileName:   util.TS_SQL,
 		})
 	}
@@ -241,7 +241,7 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_STORE,
-			RemotePath: d.remotes[host].UpDataPath + util.Remote_bin_rel_path,
+			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
 			FileName:   util.TS_STORE,
 		})
 	}
@@ -255,13 +255,13 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Download_dst + util.Local_etc_rel_path + host + util.Remote_conf_suffix,
-			RemotePath: d.remotes[host].UpDataPath + util.Remote_etc_rel_path,
+			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path,
 			FileName:   host + util.Remote_conf_suffix,
 		})
 
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Install_script_path,
-			RemotePath: d.remotes[host].UpDataPath + util.Remote_etc_rel_path,
+			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path,
 			FileName:   util.Install_Script,
 		})
 	}
@@ -282,10 +282,10 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.MetaAction = append(d.runs.MetaAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
 				Args: []string{util.TS_META, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + util.Remote_bin_rel_path + util.TS_META,
-					d.remotes[host].UpDataPath + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
+					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_META,
+					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
 					util.OpenGemini_path + util.Remote_pid_path + util.META + strconv.Itoa(i) + util.Remote_pid_suffix,
 					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.META_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
 					strconv.Itoa(i)},
@@ -302,10 +302,10 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.SqlAction = append(d.runs.SqlAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
 				Args: []string{util.TS_SQL, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + util.Remote_bin_rel_path + util.TS_SQL,
-					d.remotes[host].UpDataPath + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
+					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_SQL,
+					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
 					util.OpenGemini_path + util.Remote_pid_path + util.SQL + strconv.Itoa(i) + util.Remote_pid_suffix,
 					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.SQL_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
 					strconv.Itoa(i)},
@@ -322,10 +322,10 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.StoreAction = append(d.runs.StoreAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
 				Args: []string{util.TS_STORE, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + util.Remote_bin_rel_path + util.TS_STORE,
-					d.remotes[host].UpDataPath + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
+					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_STORE,
+					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
 					util.OpenGemini_path + util.Remote_pid_path + util.STORE + strconv.Itoa(i) + util.Remote_pid_suffix,
 					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.STORE_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
 					strconv.Itoa(i)},

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"openGemini-UP/pkg/download"
 	"openGemini-UP/pkg/exec"
 	"openGemini-UP/util"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"time"
@@ -173,7 +174,7 @@ func (d *GeminiDeployer) tryConnect(needSftp bool) error {
 			// Convert relative paths to absolute paths.
 			if r.UpDataPath[:1] == "~" {
 				pwd, _ := sftpClient.Getwd()
-				r.UpDataPath = pwd + r.UpDataPath[1:]
+				r.UpDataPath = filepath.Join(pwd, r.UpDataPath[1:])
 			}
 		}
 	}
@@ -185,8 +186,8 @@ func (d *GeminiDeployer) prepareForUpload() error {
 		return util.UnexpectedNil
 	}
 	for ip, r := range d.remotes {
-		binPath := r.UpDataPath + d.version + util.Remote_bin_rel_path
-		etcPath := r.UpDataPath + d.version + util.Remote_etc_rel_path
+		binPath := filepath.Join(r.UpDataPath, d.version, util.Remote_bin_rel_path)
+		etcPath := filepath.Join(r.UpDataPath, d.version, util.Remote_etc_rel_path)
 		command := fmt.Sprintf("mkdir -p %s; mkdir -p %s;", binPath, etcPath)
 		if _, err := d.executor.ExecCommand(ip, command); err != nil {
 			return err
@@ -210,8 +211,8 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 			}
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
-			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_META,
-			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
+			LocalPath:  filepath.Join(util.Download_dst, d.version, util.Local_bin_rel_path, util.TS_META),
+			RemotePath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path),
 			FileName:   util.TS_META,
 		})
 	}
@@ -225,8 +226,8 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 			}
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
-			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_SQL,
-			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
+			LocalPath:  filepath.Join(util.Download_dst, d.version, util.Local_bin_rel_path, util.TS_SQL),
+			RemotePath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path),
 			FileName:   util.TS_SQL,
 		})
 	}
@@ -240,8 +241,8 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 			}
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
-			LocalPath:  util.Download_dst + "/" + d.version + util.Local_bin_rel_path + util.TS_STORE,
-			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path,
+			LocalPath:  filepath.Join(util.Download_dst, d.version, util.Local_bin_rel_path, util.TS_STORE),
+			RemotePath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path),
 			FileName:   util.TS_STORE,
 		})
 	}
@@ -254,14 +255,14 @@ func (d *GeminiDeployer) prepareUploadActions(c *config.Config) error {
 			}
 		}
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
-			LocalPath:  util.Download_dst + util.Local_etc_rel_path + host + util.Remote_conf_suffix,
-			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path,
+			LocalPath:  filepath.Join(util.Download_dst, util.Local_etc_rel_path, host+util.Remote_conf_suffix),
+			RemotePath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path),
 			FileName:   host + util.Remote_conf_suffix,
 		})
 
 		d.uploads[host].uploadInfo = append(d.uploads[host].uploadInfo, &config.UploadInfo{
 			LocalPath:  util.Install_script_path,
-			RemotePath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path,
+			RemotePath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path),
 			FileName:   util.Install_Script,
 		})
 	}
@@ -282,12 +283,12 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.MetaAction = append(d.runs.MetaAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, util.Install_Script),
 				Args: []string{util.TS_META, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_META,
-					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
-					util.OpenGemini_path + util.Remote_pid_path + util.META + strconv.Itoa(i) + util.Remote_pid_suffix,
-					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.META_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path, util.TS_META),
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, host+util.Remote_conf_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_pid_path, util.META+strconv.Itoa(i)+util.Remote_pid_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_log_path, strconv.Itoa(i), util.META_extra_log+strconv.Itoa(i)+util.Remote_log_suffix),
 					strconv.Itoa(i)},
 			},
 			Remote: d.remotes[host],
@@ -302,12 +303,12 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.SqlAction = append(d.runs.SqlAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, util.Install_Script),
 				Args: []string{util.TS_SQL, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_SQL,
-					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
-					util.OpenGemini_path + util.Remote_pid_path + util.SQL + strconv.Itoa(i) + util.Remote_pid_suffix,
-					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.SQL_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path, util.TS_SQL),
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, host+util.Remote_conf_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_pid_path, util.SQL+strconv.Itoa(i)+util.Remote_pid_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_log_path, strconv.Itoa(i), util.SQL_extra_log+strconv.Itoa(i)+util.Remote_log_suffix),
 					strconv.Itoa(i)},
 			},
 			Remote: d.remotes[host],
@@ -322,12 +323,12 @@ func (d *GeminiDeployer) prepareRunActions(c *config.Config) error {
 
 		d.runs.StoreAction = append(d.runs.StoreAction, &exec.RunAction{
 			Info: &exec.RunInfo{
-				ScriptPath: d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + util.Install_Script,
+				ScriptPath: filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, util.Install_Script),
 				Args: []string{util.TS_STORE, util.OpenGemini_path,
-					d.remotes[host].UpDataPath + d.version + util.Remote_bin_rel_path + util.TS_STORE,
-					d.remotes[host].UpDataPath + d.version + util.Remote_etc_rel_path + host + util.Remote_conf_suffix,
-					util.OpenGemini_path + util.Remote_pid_path + util.STORE + strconv.Itoa(i) + util.Remote_pid_suffix,
-					util.OpenGemini_path + util.Remote_log_path + strconv.Itoa(i) + util.STORE_extra_log + strconv.Itoa(i) + util.Remote_log_suffix,
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_bin_rel_path, util.TS_STORE),
+					filepath.Join(d.remotes[host].UpDataPath, d.version, util.Remote_etc_rel_path, host+util.Remote_conf_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_pid_path, util.STORE+strconv.Itoa(i)+util.Remote_pid_suffix),
+					filepath.Join(util.OpenGemini_path, util.Remote_log_path, strconv.Itoa(i), util.STORE_extra_log+strconv.Itoa(i)+util.Remote_log_suffix),
 					strconv.Itoa(i)},
 			},
 			Remote: d.remotes[host],
@@ -357,7 +358,7 @@ func (d *GeminiDeployer) uploadFiles() {
 			for _, c := range action.uploadInfo {
 				// check whether need to upload the file
 				// only support Linux
-				cmd := fmt.Sprintf("if [ -f %s ]; then echo 'File exists'; else echo 'File not found'; fi", c.RemotePath+c.FileName)
+				cmd := fmt.Sprintf("if [ -f %s ]; then echo 'File exists'; else echo 'File not found'; fi", filepath.Join(c.RemotePath, c.FileName))
 				output, err := d.executor.ExecCommand(ip, cmd)
 				if string(output) == "File exists\n" && err == nil {
 					fmt.Printf("%s exists on %s.\n", c.FileName, c.RemotePath)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -38,7 +38,7 @@ func NewGeminiDownloader(version string) Downloader {
 		website:     util.Download_web,
 		version:     version,
 		typ:         util.Download_type,
-		destination: util.Download_dst + "/",
+		destination: util.Download_dst,
 		timeout:     util.Download_timeout,
 	}
 }
@@ -93,7 +93,7 @@ func (d *GeminiDownloader) Run() error {
 	}
 
 	if d.isMissing() { // check whether need to download the files
-		dir := d.destination + d.version
+		dir := filepath.Join(d.destination, d.version)
 		if err := d.spliceUrl(); err != nil {
 			d.CleanFile(dir)
 			return err
@@ -114,13 +114,13 @@ func (d *GeminiDownloader) Run() error {
 }
 
 func (d *GeminiDownloader) isMissing() bool {
-	dir := d.destination + d.version
+	dir := filepath.Join(d.destination, d.version)
 	_, err := os.Stat(dir)
 	return os.IsNotExist(err)
 }
 
 func (d *GeminiDownloader) downloadFile() error {
-	dir := d.destination + d.version
+	dir := filepath.Join(d.destination, d.version)
 	fmt.Printf("start downloading file from %s to %s\n", d.Url, dir)
 
 	var client *http.Client
@@ -168,7 +168,7 @@ func (d *GeminiDownloader) downloadFile() error {
 	}
 	fmt.Printf("mkdir: %s\n", dir)
 	idx := strings.LastIndex(d.Url, "/")
-	dst := dir + "/" + d.Url[idx+1:]
+	dst := filepath.Join(dir, d.Url[idx+1:])
 	out, err := os.Create(dst)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func (d *GeminiDownloader) downloadFile() error {
 }
 
 func (d *GeminiDownloader) decompressFile() error {
-	targetPath := d.destination + d.version + "/"
+	targetPath := filepath.Join(d.destination, d.version)
 	fmt.Printf("start decompressing %s to %s\n", d.fileName, targetPath)
 
 	// open .tar.gz file

--- a/util/const.go
+++ b/util/const.go
@@ -16,8 +16,8 @@ const (
 
 // local
 const (
-	Local_bin_rel_path = "/usr/bin/"
-	Local_etc_rel_path = "/etc/"
+	Local_bin_rel_path = "usr/bin"
+	Local_etc_rel_path = "etc"
 )
 
 // config
@@ -41,19 +41,19 @@ const (
 // remote
 const (
 	// openGemini-UP
-	Remote_bin_rel_path = "/bin/"
-	Remote_etc_rel_path = "/etc/"
+	Remote_bin_rel_path = "bin"
+	Remote_etc_rel_path = "etc"
 
 	// openGemini
 	OpenGemini_path   = "/tmp/openGemini"
-	Remote_pid_path   = "/pid/"
-	Remote_log_path   = "/logs/"
+	Remote_pid_path   = "pid"
+	Remote_log_path   = "logs"
 	Remote_pid_suffix = ".pid"
 	Remote_log_suffix = ".log"
 
-	META_extra_log  = "/meta_extra"
-	SQL_extra_log   = "/sql_extra"
-	STORE_extra_log = "/store_extra"
+	META_extra_log  = "meta_extra"
+	SQL_extra_log   = "sql_extra"
+	STORE_extra_log = "store_extra"
 	META            = "meta"
 	SQL             = "sql"
 	STORE           = "store"

--- a/util/const.go
+++ b/util/const.go
@@ -41,8 +41,8 @@ const (
 // remote
 const (
 	// openGemini-UP
-	Remote_bin_rel_path = "bin/"
-	Remote_etc_rel_path = "etc/"
+	Remote_bin_rel_path = "/bin/"
+	Remote_etc_rel_path = "/etc/"
 
 	// openGemini
 	OpenGemini_path   = "/tmp/openGemini"


### PR DESCRIPTION
Issue Number: close #3

Implementing the `upgrade` command allows for one click upgrade of the openGemini cluster, ensuring that all components are upgraded to the same specified version and cluster services are restored correctly.

Example of usage methods is: `./openGemini-UP cluster upgrade --version v1.0.1`