### PR TITLE
bug: fix cluster start without version number

### DIFF
--- a/util/const.go
+++ b/util/const.go
@@ -58,3 +58,8 @@ const (
 	SQL             = "sql"
 	STORE           = "store"
 )
+
+// version
+const (
+	VersionFile = "version"
+)


### PR DESCRIPTION
Issue Number: close #5

Since the version information of the cluster is not persisted, the version number information is lost when the cluster is started, causing the cluster to fail to start successfully.
In the modified code, the cluster version information is persisted during `deploy` and `upgrade` operations, so the cluster version number can be correctly obtained when starting the cluster. The recurrence scenario mentioned in the issue #5 has also been successfully solved.