### PR TITLE
fix: print verbose debug logs always

### DIFF
--- a/cmd/cluster/root.go
+++ b/cmd/cluster/root.go
@@ -93,14 +93,13 @@ func Execute() {
 
 	if err != nil {
 		gui.ColorErrorMsg.Fprintf(os.Stderr, "\nError: %s", err.Error())
-	}
 
-	logger.OutputDebugLog("gemix-cluster")
+		logger.OutputDebugLog("gemix-cluster")
+	}
 
 	err = logger.OutputAuditLogIfEnabled()
 	if err != nil {
 		zap.L().Warn("Write audit log file failed", zap.Error(err))
-		code = 1
 	}
 
 	color.Unset()

--- a/pkg/cluster/operation/uninstall.go
+++ b/pkg/cluster/operation/uninstall.go
@@ -191,7 +191,6 @@ func DestroyComponent(ctx context.Context, instances []spec.Instance, cls spec.T
 
 	logger := ctx.Value(logprinter.ContextKeyLogger).(*logprinter.Logger)
 	name := instances[0].ComponentName()
-	fmt.Printf("Destroying component %s\n", name)
 	logger.Infof("Destroying component %s\n", name)
 
 	retainDataRoles := set.NewStringSet(options.RetainDataRoles...)


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close #36

### What is changed and how it works?

fix: print verbose debug logs always

### How Has This Been Tested?

execute the cmd: `./gemix cluster -h`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
