### PR TITLE
fix: start and uninstall ts-monitor failed

### DIFF
--- a/pkg/cluster/spec/instance.go
+++ b/pkg/cluster/spec/instance.go
@@ -131,8 +131,12 @@ func (i *BaseInstance) InitConfig(ctx context.Context, e ctxt.Executor, opt Glob
 	comp := i.ComponentName()
 	host := i.GetHost()
 	port := i.GetPort()
-	sysCfg := filepath.Join(paths.Cache, fmt.Sprintf("%s-%s-%d.service", comp, host, port))
-
+	var sysCfg string
+	if port > 0 {
+		sysCfg = filepath.Join(paths.Cache, fmt.Sprintf("%s-%s-%d.service", comp, host, port))
+	} else {
+		sysCfg = filepath.Join(paths.Cache, fmt.Sprintf("%s-%s.service", comp, host))
+	}
 	resource := MergeResourceControl(opt.ResourceControl, i.ResourceControl())
 	systemCfg := system.NewConfig(comp, user, paths.Deploy).
 		WithMemoryLimit(resource.MemoryLimit).

--- a/pkg/cluster/spec/spec.go
+++ b/pkg/cluster/spec/spec.go
@@ -178,13 +178,14 @@ func fillCustomDefaults(globalOptions *GlobalOptions, data any) error {
 
 var (
 	globalOptionTypeName  = reflect.TypeOf(GlobalOptions{}).Name()
+	monitorOptionTypeName = reflect.TypeOf(TSMonitoredOptions{}).Name()
 	serverConfigsTypeName = reflect.TypeOf(ServerConfigs{}).Name()
 )
 
 // Skip global/monitored options
 func isSkipField(field reflect.Value) bool {
 	tp := field.Type().Name()
-	return tp == globalOptionTypeName || tp == serverConfigsTypeName
+	return tp == globalOptionTypeName || tp == monitorOptionTypeName || tp == serverConfigsTypeName
 }
 
 func setDefaultDir(parent, role, port string, field reflect.Value) {

--- a/pkg/cluster/spec/ts_monitor.go
+++ b/pkg/cluster/spec/ts_monitor.go
@@ -16,6 +16,7 @@ package spec
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -259,7 +260,7 @@ func (i *TSMonitorInstance) InitConfig(ctx context.Context, e ctxt.Executor, clu
 	}
 	spec := i.InstanceSpec.(*TSMonitorSpec)
 
-	cfg := &scripts.TSSqlScript{
+	cfg := &scripts.TSMonitorScript{
 		DeployDir: paths.Deploy,
 		LogDir:    paths.Log,
 	}
@@ -303,4 +304,9 @@ func (i *TSMonitorInstance) SetDefaultConfig(instanceConf map[string]any) map[st
 	//instanceConf["logging.path"] = i.LogDir()
 
 	return instanceConf
+}
+
+// Ready implements Instance interface
+func (i *TSMonitorInstance) Ready(ctx context.Context, e ctxt.Executor, timeout uint64, _ *tls.Config) error {
+	return nil
 }

--- a/pkg/cluster/spec/validate.go
+++ b/pkg/cluster/spec/validate.go
@@ -56,7 +56,6 @@ func (s *Specification) CountDir(targetHost, dirPrefix string) int {
 		if isSkipField(topoSpec.Field(i)) {
 			continue
 		}
-
 		compSpecs := topoSpec.Field(i)
 		for index := 0; index < compSpecs.Len(); index++ {
 			compSpec := reflect.Indirect(compSpecs.Index(index))

--- a/pkg/cluster/template/scripts/ts_monitor.go
+++ b/pkg/cluster/template/scripts/ts_monitor.go
@@ -1,0 +1,51 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scripts
+
+import (
+	"bytes"
+	"path"
+	"text/template"
+
+	"github.com/openGemini/gemix/embed"
+	"github.com/openGemini/gemix/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+// TSMonitorScript represent the data to generate ts-monitor config
+type TSMonitorScript struct {
+	DeployDir string
+	LogDir    string
+}
+
+// ConfigToFile write config content to specific path
+func (c *TSMonitorScript) ConfigToFile(file string) error {
+	fp := path.Join("templates", "scripts", "run_ts_monitor.sh.tpl")
+	tpl, err := embed.ReadTemplate(fp)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	tmpl, err := template.New("TSMonitor").Parse(string(tpl))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	content := bytes.NewBufferString("")
+	if err := tmpl.Execute(content, c); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return utils.WriteFile(file, content.Bytes(), 0750)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close #12

### What is changed and how it works?

feat: support install grafana and ts-monitor

### How Has This Been Tested?

- [x] test by `gemix install`

![image](https://github.com/openGemini/openGemini-UP/assets/22270117/5562ed66-f10e-47cc-aeb5-b0a2ef9035c7)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
