### PR TITLE
[fix] download.go : Fail to gemix cluster install ... cause that grafana:7.5.17 's download url is changed

### DIFF
--- a/pkg/cluster/operation/download.go
+++ b/pkg/cluster/operation/download.go
@@ -49,7 +49,13 @@ func Download(prefix, component, nodeOS, arch, version string) error {
 			arch = "amd64"
 		}
 		fileName = fmt.Sprintf("%s-enterprise-%s.%s-%s.tar.gz", component, ver.GrafanaVersion, nodeOS, arch)
-		componentUrl = strings.Join([]string{"https://dl.grafana.com/oss/release", fileName}, "/")
+		// FIX for : https://github.com/openGemini/gemix/issues/67
+                grafanaBaseUrlEnv := os.Getenv("GRAFANA_BASE_URL");
+                if grafanaBaseUrlEnv == "" {
+                    grafanaBaseUrlEnv = "https://dl.grafana.com/enterprise/release"; //"https://dl.grafana.com/oss/release" is Deprecated
+                }
+                //componentUrl = strings.Join([]string{"https://dl.grafana.com/oss/release", fileName}, "/")
+		componentUrl = strings.Join([]string{ grafanaBaseUrlEnv, fileName}, "/")
 	}
 	dstPath := spec.ProfilePath(spec.OpenGeminiPackageCacheDir, fileName)
 	if err := os.MkdirAll(spec.ProfilePath(spec.OpenGeminiPackageCacheDir), 0750); err != nil {


### PR DESCRIPTION
…ana:7.5.17 's download url is changed. throw exception: "Error: receiving status of 404 for url: https://dl.grafana.com/oss/release/grafana-enterprise-7.5.17.linux-amd64.tar.gz" #67

https://github.com/openGemini/gemix/issues/67

<!-- Thank you for contributing to openGemini! -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close", "fix", "resolve" or "ref".
-->

Issue Number: close/fix/resolve/ref #xxx

### What is changed and how it works?
fix the bug:
[Fail to gemix cluster install ... cause that grafana:7.5.17 's download url is changed. throw exception: "Error: receiving status of 404 for url: https://dl.grafana.com/oss/release/grafana-enterprise-7.5.17.linux-amd64.tar.gz" #67](https://github.com/openGemini/gemix/issues/67)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [ ] Test cases to be added
- [√] No code

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
